### PR TITLE
Fix generateNotificationHash

### DIFF
--- a/src/payments/online/paybylink/paybylink.payment.ts
+++ b/src/payments/online/paybylink/paybylink.payment.ts
@@ -53,7 +53,7 @@ export class PaybylinkPayment extends BasePayment {
             payload['transactionId'],
             payload['control'],
             payload['email'],
-            payload['amountPaid'],
+            payload['amountPaid'].toFixed(2),
             payload['notificationAttempt'],
             payload['paymentType'],
             payload['apiVersion']


### PR DESCRIPTION
Paybylink uses %.2f when generating the signature